### PR TITLE
ecm timer stealth only

### DIFF
--- a/HoloInfo/lua/ECMJammerBase.lua
+++ b/HoloInfo/lua/ECMJammerBase.lua
@@ -3,7 +3,7 @@ HoloInfo:clone(ECMJammerBase)
 function ECMJammerBase:set_active(active, ...)
 	self.old.set_active(self,active ,...)
 	if HoloInfo._hudinfo then
-		if active == true then
+		if active == true and managers.groupai:state():whisper_mode() then
 		    HoloInfo._hudinfo:create_timer(self._unit:id())
 	    end
 	end


### PR DESCRIPTION
the current one active will still count down it its placed before it goes loud to prevent it from getting stuck on the screen. Any new ecms placed after the heist is loud won't show up